### PR TITLE
Fix for aicw function for handling mvSHIFT input

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -26,9 +26,9 @@ aicw <- function(x,...){
         
                 models_names <- sapply(1:length(x),function(i){
                     if(!is.null(x[[i]]$param[["constraint"]])){
-                        paste(x[[i]]$param$model,x[[i]]$param$constraint,i)
+                        paste(x[[i]]$param$model[length(x[[i]]$param$model)],x[[i]]$param$constraint,i)
                     }else{
-                        paste(x[[i]]$param$model,i)}
+                        paste(x[[i]]$param$model[length(x[[i]]$param$model)],i)}
                 })
         }else{
         aic_model <- unlist(x)


### PR DESCRIPTION
The `aicw` function throws the following error when passing in a list that includes mvSHIFT outputs:

```
Error in data.frame(models = models_names, AIC = aic_model, diff = aic_model) : 
  arguments imply differing number of rows: 2, 3
```

Notice that the output of `mvBM(...)$param$model` is a vector of characters of length 1, as is the output of `mvOU(...)$param$model`, `mvEB(...)$param$model`, etc. 

However, the output of `mvSHIFT(...)$param$model` is a vector of characters of length 2. 

At line 27 of utils.r, `models_names` is intended to be 1 dimensional vector of characters, but when `mvSHIFT` outputs are passed into the `aicw` function, `models_names` becomes 2 dimensional (see both calls of the `paste` function). This then causes an error at line 37 when `models_names` is used to create the data frame `aics`.

To fix this, I force `models_names` to be 1 dimensional by replacing calls for `x[[i]]$param$model` (which might be a vector of length 1 or 2) with the last string in the vector, indexing by the length. (Note that the relevant character in `mvSHIFT(...)$param$model` is the second of two elements in the vector.)

Please also note that the error described above does not occur when you call: `aicw( list(mvBM(...), mvSHIFT(...) ) )`
I have not figured out why this is the case, but to reproduce this error, try: `aicw( list(mvBM(...), mvEB(...), mvSHIFT(...) ) )`
Or: `aicw( list(mvSHIFT(...), mvSHIFT(...) ) )`