### PR TITLE
EmpBayes FCI and mapping.asr

### DIFF
--- a/R/mvgls.r
+++ b/R/mvgls.r
@@ -189,6 +189,7 @@ mvgls <- function(formula, data=list(), tree, model, method=c("PL-LOOCV","LL"), 
     # Computing confidence intervals using the Fisher information matrix. Only available for method='EmpBayes'
     if(FCI){
       if(method!="EmpBayes") warning("The CI are available only for the EmpBayes method") else if(method=="EmpBayes"){
+          if(model=="BM") fci = NA else{
         fisher_information<-solve(estimModel$hessian) # it's already the negative of the Hessian since the negative ll is minimized
         sigma_for_ci<-sqrt(diag(fisher_information)) # the first entry is for the "regularization" term. For ML optimization it will be the first term
         
@@ -197,7 +198,7 @@ mvgls <- function(formula, data=list(), tree, model, method=c("PL-LOOCV","LL"), 
         upper_ci<-mod_par+1.96*sigma_for_ci[2:npar_for_ci]
         lower_ci<-mod_par-1.96*sigma_for_ci[2:npar_for_ci]
         fci = c('lw'=lower_ci, 'up'=upper_ci)
-      }
+      }}
     }
     
     # Multiple rates BMM - we scale the average rate (mean of the diagonal of the covariance matrix)

--- a/R/utils.r
+++ b/R/utils.r
@@ -61,4 +61,30 @@ aicw <- function(x,...){
    return(aics)
 }
 
+# ------------------------------------------------------------------------- #
+# Function to transform ancestral states reconstruction to a tree of class  #
+# "simmap"  (push to mvMORPH? current version is a bit quick & dirty)       #
+#                                                      J. CLAVEL - 2020     #
+# ------------------------------------------------------------------------- #
 
+# tree = the phylogenetic tree
+# ancestral = either a "describe.simmap" object from phytools or an "ace" object from ape.
+# tips = states at the tips. Check that the tree and data are in same order!
+
+mapping.asr <- function(tree, ancestral, tips){
+  
+  if(inherits(ancestral, "describe.simmap")){
+    names_grps <- colnames(ancestral$ace)
+    statesNodes <- names_grps[apply(ancestral$ace, 1, which.max)]
+  }else{
+    names_grps <- colnames(ancestral$lik.anc)
+    statesNodes <- names_grps[apply(ancestral$lik.anc, 1, which.max)]
+  }
+  
+  combined = as.character(c(tips, statesNodes))
+  treebis=tree
+  for(i in sort(tree$edge[,2])){
+    treebis <- paintBranches(treebis, i, combined[i], anc.state=combined[Ntip(tree)+1])
+  }
+  return(treebis)
+}


### PR DESCRIPTION
Setting FCI for models other than BM and adding mapping.asr(), a function to map ancestral state reconstructions on a phylogenetic tree